### PR TITLE
feat(versioning): add workspace-env extension for manifest-driven env sync and validation

### DIFF
--- a/packages/versioning/README.md
+++ b/packages/versioning/README.md
@@ -11,6 +11,11 @@ A comprehensive versioning and changelog management tool designed for monorepos 
 ## 📋 Latest Changes (v1.4.7)
 
 ### Added
+- ✨ New `workspace-env` extension (v1.0.0)
+  - `versioning env sync` — generate per-target `.env.local` and `.env.example` files from one canonical manifest
+  - `versioning env doctor` — report missing required variables and unknown root env keys
+  - `versioning env validate` — CI-friendly validation for required variables (non-zero exit on missing vars)
+  - Supports manifest sources, aliases, canonical variable metadata, and target key mapping
 - ✨ New `workspace-scripts` extension (v1.0.0)
   - `versioning scripts sync` — auto-generate `dev:all`, `build:all`, and per-app scripts in root package.json
   - `versioning scripts list` — display current workspace script configuration
@@ -113,6 +118,34 @@ Extensions can hook into the versioning lifecycle:
 - `postSync`: Called after version sync
 
 ### Built-in Extensions
+
+#### Workspace Env Extension
+
+Adds first-class workspace environment orchestration for monorepos:
+
+```bash
+versioning env sync
+versioning env doctor
+versioning env validate --target landing
+```
+
+Manifest default lookup order:
+- `config/env/manifest.cjs`
+- `config/env/manifest.js`
+- `config/env/manifest.json`
+
+Basic config (`versioning.config.json`):
+
+```json
+{
+  "extensionConfig": {
+    "workspace-env": {
+      "enabled": true,
+      "manifestPath": "config/env/manifest.cjs"
+    }
+  }
+}
+```
 
 #### Lifecycle Hooks Extension
 

--- a/packages/versioning/src/__tests__/workspace-env-extension.test.ts
+++ b/packages/versioning/src/__tests__/workspace-env-extension.test.ts
@@ -1,0 +1,105 @@
+// Unmock fs-extra since workspace env tests need real filesystem access
+jest.unmock('fs-extra');
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import extension, {
+  EnvManifest,
+  parseEnvContent,
+  syncWorkspaceEnv,
+  validateWorkspaceEnv,
+} from '../extensions/workspace-env/index';
+import { Command } from 'commander';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workspace-env-test-'));
+});
+
+afterEach(async () => {
+  if (tmpDir && await fs.pathExists(tmpDir)) {
+    await fs.remove(tmpDir);
+  }
+});
+
+describe('workspace-env extension helpers', () => {
+  it('parses dotenv content and ignores comments', () => {
+    const parsed = parseEnvContent(`# comment\nAPI_URL=https://api.example.com\nEMPTY=\nQUOTED="value"\n`);
+    expect(parsed.API_URL).toBe('https://api.example.com');
+    expect(parsed.EMPTY).toBe('');
+    expect(parsed.QUOTED).toBe('value');
+  });
+
+  it('syncs target env files and generates examples', async () => {
+    await fs.writeFile(path.join(tmpDir, '.env'), 'API_BASE_URL=https://api.example.com\nSHARED_TOKEN=topsecret\n');
+
+    const manifest: EnvManifest = {
+      sources: ['.env'],
+      targets: {
+        landing: { path: 'apps/landing' },
+      },
+      variables: {
+        API_BASE_URL: {
+          description: 'Base URL',
+          required: true,
+          targets: { landing: 'NEXT_PUBLIC_API_BASE_URL' },
+        },
+        SHARED_TOKEN: {
+          description: 'Private token',
+          secret: true,
+          required: true,
+          targets: { landing: 'SHARED_TOKEN' },
+        },
+      },
+    };
+
+    const summary = await syncWorkspaceEnv(tmpDir, manifest);
+    expect(summary.missingRequired).toHaveLength(0);
+
+    const targetEnv = await fs.readFile(path.join(tmpDir, 'apps/landing/.env.local'), 'utf-8');
+    expect(targetEnv).toContain('NEXT_PUBLIC_API_BASE_URL=https://api.example.com');
+    expect(targetEnv).toContain('SHARED_TOKEN=topsecret');
+
+    const targetExample = await fs.readFile(path.join(tmpDir, 'apps/landing/.env.example'), 'utf-8');
+    expect(targetExample).toContain('NEXT_PUBLIC_API_BASE_URL=https://api.example.com');
+    expect(targetExample).toContain('SHARED_TOKEN=');
+
+    const rootExample = await fs.readFile(path.join(tmpDir, '.env.example'), 'utf-8');
+    expect(rootExample).toContain('API_BASE_URL=https://api.example.com');
+  });
+
+  it('validates missing required variables and unknown root keys', async () => {
+    await fs.writeFile(path.join(tmpDir, '.env'), 'UNKNOWN_THING=yes\n');
+
+    const manifest: EnvManifest = {
+      sources: ['.env'],
+      targets: {
+        landing: { path: 'apps/landing' },
+      },
+      variables: {
+        API_BASE_URL: {
+          required: true,
+          targets: { landing: 'NEXT_PUBLIC_API_BASE_URL' },
+        },
+      },
+    };
+
+    const result = await validateWorkspaceEnv(tmpDir, manifest);
+    expect(result.ok).toBe(false);
+    expect(result.missingRequiredByTarget.landing).toContain('API_BASE_URL');
+    expect(result.unknownRootKeys).toContain('UNKNOWN_THING');
+  });
+});
+
+describe('workspace-env command registration', () => {
+  it('registers env command with sync/doctor/validate subcommands', async () => {
+    const program = new Command();
+    await extension.register(program, {});
+
+    const env = program.commands.find((c) => c.name() === 'env');
+    expect(env).toBeDefined();
+    expect(env?.commands.map((c) => c.name())).toEqual(expect.arrayContaining(['sync', 'doctor', 'validate']));
+  });
+});

--- a/packages/versioning/src/extensions/workspace-env/CHANGELOG.md
+++ b/packages/versioning/src/extensions/workspace-env/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-03-19
+
+### Added
+- Initial release of workspace env extension.
+- Added `versioning env sync`, `versioning env doctor`, and `versioning env validate` commands.
+- Added canonical manifest loading and target env/example generation.

--- a/packages/versioning/src/extensions/workspace-env/index.ts
+++ b/packages/versioning/src/extensions/workspace-env/index.ts
@@ -1,0 +1,371 @@
+import { Command } from 'commander';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { VersioningExtension } from '../../extensions';
+
+export interface EnvTargetConfig {
+  path: string;
+  envFile?: string;
+  exampleFile?: string;
+}
+
+export interface EnvVariableConfig {
+  aliases?: string[];
+  description?: string;
+  secret?: boolean;
+  required?: boolean;
+  example?: string;
+  targets?: Record<string, string>;
+}
+
+export interface EnvManifest {
+  sources?: string[];
+  variables: Record<string, EnvVariableConfig>;
+  targets: Record<string, EnvTargetConfig>;
+}
+
+export interface WorkspaceEnvConfig {
+  enabled?: boolean;
+  manifestPath?: string;
+}
+
+export interface SyncSummary {
+  changedFiles: string[];
+  unchangedFiles: string[];
+  missingRequired: string[];
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  missingRequiredByTarget: Record<string, string[]>;
+  unknownRootKeys: string[];
+}
+
+const DEFAULT_MANIFEST_CANDIDATES = [
+  'config/env/manifest.cjs',
+  'config/env/manifest.js',
+  'config/env/manifest.json'
+];
+
+export function parseEnvContent(content: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  const lines = content.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex <= 0) continue;
+
+    const key = trimmed.slice(0, eqIndex).trim();
+    let value = trimmed.slice(eqIndex + 1).trim();
+
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    values[key] = value;
+  }
+
+  return values;
+}
+
+export async function loadRootEnv(rootDir: string, sources: string[]): Promise<Record<string, string>> {
+  const merged: Record<string, string> = {};
+
+  for (const source of sources) {
+    const sourcePath = path.resolve(rootDir, source);
+    if (!(await fs.pathExists(sourcePath))) continue;
+
+    const content = await fs.readFile(sourcePath, 'utf-8');
+    const parsed = parseEnvContent(content);
+
+    Object.assign(merged, parsed);
+  }
+
+  return merged;
+}
+
+export function resolveManifestPath(rootDir: string, configuredPath?: string): string {
+  if (configuredPath) {
+    return path.resolve(rootDir, configuredPath);
+  }
+
+  for (const candidate of DEFAULT_MANIFEST_CANDIDATES) {
+    const candidatePath = path.resolve(rootDir, candidate);
+    if (fs.existsSync(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  throw new Error(
+    `Workspace env manifest not found. Searched: ${DEFAULT_MANIFEST_CANDIDATES.join(', ')}. ` +
+    'Set extensionConfig["workspace-env"].manifestPath in versioning.config.json to customize the location.'
+  );
+}
+
+export async function loadManifest(manifestPath: string): Promise<EnvManifest> {
+  const ext = path.extname(manifestPath).toLowerCase();
+
+  if (ext === '.json') {
+    return await fs.readJson(manifestPath);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const required = require(manifestPath);
+  return required.default || required;
+}
+
+function pickCanonicalValue(canonicalKey: string, variable: EnvVariableConfig, rootValues: Record<string, string>): string | undefined {
+  if (rootValues[canonicalKey] !== undefined) return rootValues[canonicalKey];
+
+  for (const alias of variable.aliases || []) {
+    if (rootValues[alias] !== undefined) return rootValues[alias];
+  }
+
+  return undefined;
+}
+
+function formatEnvFile(entries: Array<{ key: string; value: string; description?: string }>): string {
+  const lines: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.description) {
+      lines.push(`# ${entry.description}`);
+    }
+    lines.push(`${entry.key}=${entry.value}`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+async function writeIfChanged(filePath: string, content: string): Promise<boolean> {
+  const exists = await fs.pathExists(filePath);
+  if (exists) {
+    const current = await fs.readFile(filePath, 'utf-8');
+    if (current === content) return false;
+  }
+
+  await fs.ensureDir(path.dirname(filePath));
+  await fs.writeFile(filePath, content, 'utf-8');
+  return true;
+}
+
+function getRelevantTargets(manifest: EnvManifest, targetFilter?: string[]): string[] {
+  const allTargets = Object.keys(manifest.targets || {});
+  if (!targetFilter || targetFilter.length === 0) return allTargets;
+
+  return allTargets.filter((target) => targetFilter.includes(target));
+}
+
+export async function syncWorkspaceEnv(
+  rootDir: string,
+  manifest: EnvManifest,
+  options?: { targets?: string[] }
+): Promise<SyncSummary> {
+  const sources = manifest.sources || ['.env', '.env.local'];
+  const rootValues = await loadRootEnv(rootDir, sources);
+
+  const changedFiles: string[] = [];
+  const unchangedFiles: string[] = [];
+  const missingRequired: string[] = [];
+
+  const targetNames = getRelevantTargets(manifest, options?.targets);
+
+  for (const targetName of targetNames) {
+    const target = manifest.targets[targetName];
+    const targetEnvEntries: Array<{ key: string; value: string; description?: string }> = [];
+    const targetExampleEntries: Array<{ key: string; value: string; description?: string }> = [];
+
+    for (const [canonical, variable] of Object.entries(manifest.variables || {})) {
+      const mappedKey = variable.targets?.[targetName];
+      if (!mappedKey) continue;
+
+      const value = pickCanonicalValue(canonical, variable, rootValues);
+      const required = variable.required === true;
+
+      if (value === undefined && required) {
+        missingRequired.push(`${targetName}:${canonical}`);
+      }
+
+      if (value !== undefined) {
+        targetEnvEntries.push({ key: mappedKey, value, description: variable.description });
+      }
+
+      const exampleValue = variable.example ?? (variable.secret ? '' : (value ?? ''));
+      targetExampleEntries.push({ key: mappedKey, value: exampleValue, description: variable.description });
+    }
+
+    const targetDir = path.resolve(rootDir, target.path);
+    const envPath = path.join(targetDir, target.envFile || '.env.local');
+    const examplePath = path.join(targetDir, target.exampleFile || '.env.example');
+
+    const envChanged = await writeIfChanged(envPath, formatEnvFile(targetEnvEntries));
+    const exChanged = await writeIfChanged(examplePath, formatEnvFile(targetExampleEntries));
+
+    (envChanged ? changedFiles : unchangedFiles).push(path.relative(rootDir, envPath));
+    (exChanged ? changedFiles : unchangedFiles).push(path.relative(rootDir, examplePath));
+  }
+
+  const rootExampleEntries = Object.entries(manifest.variables || {}).map(([canonical, variable]) => {
+    const value = pickCanonicalValue(canonical, variable, rootValues);
+    const exampleValue = variable.example ?? (variable.secret ? '' : (value ?? ''));
+    return {
+      key: canonical,
+      value: exampleValue,
+      description: variable.description
+    };
+  });
+
+  const rootExamplePath = path.resolve(rootDir, '.env.example');
+  const rootChanged = await writeIfChanged(rootExamplePath, formatEnvFile(rootExampleEntries));
+  (rootChanged ? changedFiles : unchangedFiles).push(path.relative(rootDir, rootExamplePath));
+
+  return {
+    changedFiles,
+    unchangedFiles,
+    missingRequired
+  };
+}
+
+export async function validateWorkspaceEnv(
+  rootDir: string,
+  manifest: EnvManifest,
+  options?: { targets?: string[] }
+): Promise<ValidationResult> {
+  const sources = manifest.sources || ['.env', '.env.local'];
+  const rootValues = await loadRootEnv(rootDir, sources);
+
+  const missingRequiredByTarget: Record<string, string[]> = {};
+  const targetNames = getRelevantTargets(manifest, options?.targets);
+
+  for (const targetName of targetNames) {
+    missingRequiredByTarget[targetName] = [];
+
+    for (const [canonical, variable] of Object.entries(manifest.variables || {})) {
+      const mappedKey = variable.targets?.[targetName];
+      if (!mappedKey) continue;
+
+      if (variable.required) {
+        const value = pickCanonicalValue(canonical, variable, rootValues);
+        if (value === undefined) {
+          missingRequiredByTarget[targetName].push(canonical);
+        }
+      }
+    }
+  }
+
+  const knownKeys = new Set<string>();
+  for (const [canonical, variable] of Object.entries(manifest.variables || {})) {
+    knownKeys.add(canonical);
+    for (const alias of variable.aliases || []) {
+      knownKeys.add(alias);
+    }
+  }
+
+  const unknownRootKeys = Object.keys(rootValues).filter((k) => !knownKeys.has(k));
+  const hasMissing = Object.values(missingRequiredByTarget).some((missing) => missing.length > 0);
+
+  return {
+    ok: !hasMissing,
+    missingRequiredByTarget,
+    unknownRootKeys
+  };
+}
+
+const extension: VersioningExtension = {
+  name: 'workspace-env',
+  description: 'Workspace environment manifest management for monorepos',
+  version: '1.0.0',
+
+  register: async (program: Command, config: any) => {
+    const extensionConfig: WorkspaceEnvConfig | undefined = config?.extensionConfig?.['workspace-env'];
+
+    if (extensionConfig?.enabled === false) {
+      return;
+    }
+
+    const env = program
+      .command('env')
+      .description('Workspace env manifest tools (sync, doctor, validate)');
+
+    env
+      .command('sync')
+      .description('Generate target env files from canonical manifest')
+      .option('-t, --target <targets>', 'Comma-separated target names to process')
+      .action(async (options) => {
+        const rootDir = process.cwd();
+        const manifestPath = resolveManifestPath(rootDir, extensionConfig?.manifestPath);
+        const manifest = await loadManifest(manifestPath);
+        const targets = options.target ? String(options.target).split(',').map((t) => t.trim()) : undefined;
+
+        const summary = await syncWorkspaceEnv(rootDir, manifest, { targets });
+
+        console.log(`✅ env sync complete (${summary.changedFiles.length} changed, ${summary.unchangedFiles.length} unchanged)`);
+        if (summary.missingRequired.length > 0) {
+          console.log('⚠️  Missing required canonical variables:');
+          summary.missingRequired.forEach((m) => console.log(`  - ${m}`));
+        }
+      });
+
+    env
+      .command('doctor')
+      .description('Check missing required vars and unknown root vars')
+      .option('-t, --target <targets>', 'Comma-separated target names to validate')
+      .option('--fail-on-missing', 'Exit with non-zero code if required vars are missing', false)
+      .action(async (options) => {
+        const rootDir = process.cwd();
+        const manifestPath = resolveManifestPath(rootDir, extensionConfig?.manifestPath);
+        const manifest = await loadManifest(manifestPath);
+        const targets = options.target ? String(options.target).split(',').map((t) => t.trim()) : undefined;
+
+        const result = await validateWorkspaceEnv(rootDir, manifest, { targets });
+
+        let hasMissing = false;
+        for (const [target, missing] of Object.entries(result.missingRequiredByTarget)) {
+          if (missing.length === 0) continue;
+          hasMissing = true;
+          console.log(`❌ ${target} missing required: ${missing.join(', ')}`);
+        }
+
+        if (result.unknownRootKeys.length > 0) {
+          console.log(`⚠️  Unknown root keys: ${result.unknownRootKeys.join(', ')}`);
+        }
+
+        if (!hasMissing) {
+          console.log('✅ env doctor: no missing required variables');
+        }
+
+        if (hasMissing && options.failOnMissing) {
+          process.exit(1);
+        }
+      });
+
+    env
+      .command('validate')
+      .description('Validate env mapping (CI-friendly, fails on missing required vars)')
+      .option('-t, --target <targets>', 'Comma-separated target names to validate')
+      .action(async (options) => {
+        const rootDir = process.cwd();
+        const manifestPath = resolveManifestPath(rootDir, extensionConfig?.manifestPath);
+        const manifest = await loadManifest(manifestPath);
+        const targets = options.target ? String(options.target).split(',').map((t) => t.trim()) : undefined;
+
+        const result = await validateWorkspaceEnv(rootDir, manifest, { targets });
+        const missing = Object.entries(result.missingRequiredByTarget)
+          .filter(([, vars]) => vars.length > 0);
+
+        if (missing.length > 0) {
+          for (const [target, vars] of missing) {
+            console.log(`❌ ${target} missing required: ${vars.join(', ')}`);
+          }
+          process.exit(1);
+        }
+
+        console.log('✅ env validate: all required variables are available');
+      });
+  }
+};
+
+export default extension;


### PR DESCRIPTION
### Motivation
- Introduce a canonical, repo-level manifest to manage environment variables and generate per-target env files so services stay in sync and avoid accidental leaking or missing runtime config.
- Provide CI-friendly validation and a doctor command to detect missing required variables and unknown root keys across monorepo targets.

### Description
- Add a new built-in extension `workspace-env` in `packages/versioning/src/extensions/workspace-env/index.ts` implementing `parseEnvContent`, `loadRootEnv`, `resolveManifestPath`, `loadManifest`, `syncWorkspaceEnv`, and `validateWorkspaceEnv`, and register CLI commands `versioning env sync`, `versioning env doctor`, and `versioning env validate`.
- Emit per-target `.env.local` and `.env.example` files plus a root `.env.example`, with `writeIfChanged` to avoid rewriting unchanged files and reporting of missing required variables.
- Add unit tests exercising parsing, sync generation, validation logic, and command registration in `packages/versioning/src/__tests__/workspace-env-extension.test.ts`.
- Add a `CHANGELOG.md` for the new extension and update `packages/versioning/README.md` to document the feature and example config (`extensionConfig.workspace-env.manifestPath`).

### Testing
- Ran build for the package with `pnpm --filter @edcalderon/versioning build`, which completed successfully (TypeScript `tsc` passed).
- Attempted to run the new test file with `pnpm --filter @edcalderon/versioning test -- workspace-env-extension.test.ts`, but tests could not run in this environment due to missing/failed resolution of `ts-jest` in the workspace Jest transform configuration, causing the test command to fail.
- Executed `pnpm install` and re-ran the package `build` successfully, and attempted to add `ts-jest` but the install encountered external registry resolution/auth issues in this environment, so unit tests could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb6d01bdd083328310759d263e01cb)