### PR TITLE
feat(auth): add Supabase vendor-independence schema skeleton (public.users + sync trigger)

### DIFF
--- a/packages/auth/supabase/README.md
+++ b/packages/auth/supabase/README.md
@@ -1,0 +1,161 @@
+# `@edcalderon/auth` — Supabase Schema Reference
+
+> **Copy, don't import.** These migrations are a reference skeleton, not a published package. Copy them into your project's `supabase/migrations/` folder and apply with `supabase db push`.
+
+---
+
+## The problem
+
+When you use `@edcalderon/auth` with Supabase as the backend, your users live in `auth.users` — a table that Supabase owns and controls. This creates **vendor lock-in**: if you ever need to migrate to a different auth provider (Authentik, Firebase, Clerk, a custom OIDC server, …), your user identity data is stranded inside Supabase Auth.
+
+## The solution
+
+Two migrations that take ~5 minutes to apply and give you complete freedom to swap auth providers later:
+
+| Migration | What it does |
+|-----------|-------------|
+| [`001_create_app_users.sql`](./migrations/001_create_app_users.sql) | Creates `public.users` — your app's vendor-independent user table — plus the `upsert_oidc_user()` RPC callable with the anon key |
+| [`002_sync_auth_users_to_app_users.sql`](./migrations/002_sync_auth_users_to_app_users.sql) | Postgres trigger that keeps `auth.users → public.users` in sync automatically. Backfills existing users on first run |
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    Your application                       │
+│                                                          │
+│  @edcalderon/auth client                                 │
+│       │                                                  │
+│       ├─ email sign-up/in ──────────────────────┐        │
+│       ├─ Google / GitHub OAuth (Supabase)  ─────┤        │
+│       ├─ Authentik OIDC redirect ───────────────┤        │
+│       └─ Wallet (SIWE/SIWS) ───────────────────┐│        │
+│                                               ││        │
+└───────────────────────────────────────────────┼┼────────┘
+                                                ││
+            Supabase Auth                       ││
+         ┌──────────────┐                       ││
+         │  auth.users  │                       ││
+         └──────┬───────┘                       ││
+                │ trigger (002)                 ││
+                ▼                               ││
+         ┌──────────────────────────────────────┼┼──┐
+         │           public.users               ││  │
+         │                                      ││  │
+         │  (sub, iss) unique key               ││  │
+         │   iss='supabase'  ←──────────────────┘│  │
+         │   iss='https://sso.example.com/…' ←───┘  │
+         │   iss='https://accounts.google.com'       │
+         │   iss='your-custom-provider'              │
+         └───────────────────────────────────────────┘
+```
+
+### Identity key: `(sub, iss)`
+
+`public.users` uses the OIDC standard `(subject, issuer)` pair as its unique identity key. This means **multiple auth providers coexist in the same table without collisions**:
+
+| Auth method | `sub` | `iss` |
+|-------------|-------|-------|
+| Supabase Auth (email, OAuth) | `auth.users.id` | `'supabase'` |
+| Authentik OIDC | Authentik user UUID | `'https://sso.example.com/application/o/app/'` |
+| Auth0 | Auth0 user ID | `'https://your-tenant.auth0.com/'` |
+| Firebase Auth | Firebase UID | `'https://securetoken.google.com/<project>'` |
+| Custom OIDC | JWT `sub` | JWT `iss` |
+
+---
+
+## Write paths
+
+### 1. Supabase Auth users (email + OAuth brokered by Supabase)
+
+**Automatic** — handled by the trigger in `002`. No app code changes needed.
+
+```
+User signs up with email
+       ↓
+auth.users INSERT
+       ↓
+trg_auth_users_sync_to_app_users fires
+       ↓
+public.users upserted  ✓
+```
+
+Email confirmation is also handled: when the user clicks the magic link,
+`email_confirmed_at` is set → trigger fires again → `email_verified` flips to `true`.
+
+### 2. External OIDC providers (Authentik, Auth0, custom)
+
+Call `upsert_oidc_user()` from the client after a successful OIDC redirect.
+The function is `SECURITY DEFINER` so it works with the **anon key** — no service-role credential needed on the client.
+
+```typescript
+// After exchanging the OIDC code for tokens and fetching userinfo:
+const { data } = await supabase.rpc('upsert_oidc_user', {
+  p_sub:            claims.sub,
+  p_iss:            claims.iss,          // OIDC issuer URL
+  p_email:          claims.email,
+  p_email_verified: claims.email_verified ?? false,
+  p_name:           claims.name,
+  p_picture:        claims.picture,
+  p_provider:       'google',            // which social provider was brokered
+  p_raw_claims:     claims,
+});
+const appUserId = data.id;               // your app's own UUID
+```
+
+### 3. Server-side webhooks (Authentik model_created/updated events)
+
+Call `upsert_oidc_user()` from your API with the service-role key.
+Useful for syncing users created via the Authentik admin UI or email flow.
+
+```typescript
+// NestJS / Express webhook handler:
+await supabase.rpc('upsert_oidc_user', {
+  p_sub:   event.body.sub,
+  p_iss:   AUTHENTIK_ISSUER,
+  p_email: event.body.email,
+  // …
+});
+```
+
+---
+
+## How to apply
+
+```bash
+# Copy into your project
+cp packages/auth/supabase/migrations/*.sql your-project/supabase/migrations/
+
+# Apply to remote Supabase project
+supabase db push
+```
+
+Or apply directly via psql:
+
+```bash
+psql "$DATABASE_URL" -f 001_create_app_users.sql
+psql "$DATABASE_URL" -f 002_sync_auth_users_to_app_users.sql
+```
+
+---
+
+## Migration path away from Supabase Auth
+
+When you're ready to drop Supabase Auth:
+
+1. `public.users` already has every user (trigger + backfill)
+2. Point your new auth provider at `public.users` using the `(sub, iss)` key from that provider's tokens
+3. Drop the `002` trigger once Supabase Auth is no longer the write path
+4. Remove `auth.users` FK references from your schema
+
+Your user data survives intact. No data migration needed.
+
+---
+
+## Compatibility
+
+- Supabase (all plans)
+- PostgreSQL ≥ 14
+- `@edcalderon/auth` ≥ 1.0.0
+- Works alongside `auth.users` — does not replace or modify it

--- a/packages/auth/supabase/migrations/001_create_app_users.sql
+++ b/packages/auth/supabase/migrations/001_create_app_users.sql
@@ -1,0 +1,142 @@
+-- =============================================================================
+-- 001_create_app_users.sql
+-- Vendor-independent user registry for projects using @edcalderon/auth.
+--
+-- WHY THIS EXISTS
+-- ───────────────
+-- Supabase Auth stores users in auth.users — a table owned and managed by the
+-- Supabase platform. This couples your user identity data to the vendor. If you
+-- ever need to migrate to a different auth provider (Firebase, Authentik, Clerk,
+-- custom OIDC, …), you lose access to that table.
+--
+-- This migration creates public.users: your app's own copy of user identity.
+-- It uses a (sub, iss) identity key compatible with the OIDC standard, so any
+-- auth provider (Supabase Auth, Authentik, Auth0, Firebase, wallet-based, …)
+-- can write to the same table without collisions.
+--
+-- IDENTITY KEY
+-- ────────────
+--   sub  – subject claim (OIDC) or auth.users.id for Supabase Auth users
+--   iss  – issuer identifier:
+--             'supabase'                           → Supabase Auth users
+--             'https://sso.example.com/o/app/'    → Authentik OIDC users
+--             'https://accounts.google.com'        → Google OIDC direct
+--             … any stable issuer string
+--
+-- WRITE PATH
+-- ──────────
+--   • Supabase Auth users  → trigger in 002_sync_auth_users_to_app_users.sql
+--   • OIDC / external OIDC → client calls upsert_oidc_user() RPC with anon key
+--   • Authentik webhook    → server calls upsert_oidc_user() with service key
+-- =============================================================================
+
+create extension if not exists pgcrypto;
+
+-- ─── Table ───────────────────────────────────────────────────────────────────
+
+create table if not exists public.users (
+  id             uuid        primary key default gen_random_uuid(),
+  sub            text        not null,
+  iss            text        not null,
+  email          text,
+  email_verified boolean     not null default false,
+  name           text,
+  picture        text,
+  -- Social provider that was brokered: 'email' | 'google' | 'discord' | …
+  provider       text,
+  -- Full raw claims from the OIDC token / Supabase user_metadata
+  raw_claims     jsonb       not null default '{}'::jsonb,
+  created_at     timestamptz not null default timezone('utc', now()),
+  updated_at     timestamptz not null default timezone('utc', now()),
+
+  constraint users_sub_iss_uq    unique (sub, iss),
+  constraint users_sub_len_chk   check (char_length(sub) <= 256),
+  constraint users_iss_len_chk   check (char_length(iss) <= 512),
+  constraint users_email_len_chk check (email is null or char_length(email) <= 320)
+);
+
+create index if not exists users_email_idx
+  on public.users (lower(email)) where email is not null;
+
+create index if not exists users_provider_idx
+  on public.users (provider) where provider is not null;
+
+-- ─── Auto-bump updated_at ────────────────────────────────────────────────────
+
+create or replace function public.users_set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_users_set_updated_at on public.users;
+create trigger trg_users_set_updated_at
+before update on public.users
+for each row execute function public.users_set_updated_at();
+
+-- ─── upsert_oidc_user ────────────────────────────────────────────────────────
+-- Called from:
+--   • Mobile / web client after a successful OIDC redirect (with anon key)
+--   • Server-side webhook handler (Authentik, Auth0 events, …)
+--
+-- SECURITY DEFINER: the anon role can write to public.users without needing the
+-- service-role key. The function enforces its own logic; RLS is still active for
+-- direct table queries.
+
+create or replace function public.upsert_oidc_user(
+  p_sub            text,
+  p_iss            text,
+  p_email          text          default null,
+  p_email_verified boolean       default false,
+  p_name           text          default null,
+  p_picture        text          default null,
+  p_provider       text          default null,
+  p_raw_claims     jsonb         default '{}'::jsonb
+)
+returns public.users
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user public.users;
+begin
+  insert into public.users (
+    sub, iss, email, email_verified, name, picture, provider, raw_claims
+  )
+  values (
+    p_sub, p_iss, p_email, p_email_verified,
+    p_name, p_picture, p_provider, p_raw_claims
+  )
+  on conflict (sub, iss) do update
+    set email          = excluded.email,
+        email_verified = excluded.email_verified,
+        name           = excluded.name,
+        picture        = excluded.picture,
+        provider       = excluded.provider,
+        raw_claims     = excluded.raw_claims,
+        updated_at     = timezone('utc', now())
+  returning * into v_user;
+
+  return v_user;
+end;
+$$;
+
+-- Grant to both roles so the client can call it with anon key and authenticated
+-- sessions both work (Supabase routes based on the JWT role claim).
+grant execute
+  on function public.upsert_oidc_user(text, text, text, boolean, text, text, text, jsonb)
+  to anon, authenticated;
+
+-- ─── Row-level security ──────────────────────────────────────────────────────
+-- Enable RLS. Writes go exclusively through upsert_oidc_user (DEFINER).
+-- Add SELECT policies once your app has a JWT-based session strategy.
+-- Example policy (uncomment when ready):
+--
+--   create policy users_select_own on public.users
+--     for select to authenticated
+--     using (sub = (current_setting('request.jwt.claims', true)::jsonb ->> 'sub'));
+
+alter table public.users enable row level security;

--- a/packages/auth/supabase/migrations/002_sync_auth_users_to_app_users.sql
+++ b/packages/auth/supabase/migrations/002_sync_auth_users_to_app_users.sql
@@ -1,0 +1,142 @@
+-- =============================================================================
+-- 002_sync_auth_users_to_app_users.sql
+-- Trigger: keep auth.users → public.users in sync automatically.
+--
+-- Depends on: 001_create_app_users.sql
+--
+-- WHY A TRIGGER?
+-- ──────────────
+-- Without this, only users who authenticate through an explicit OIDC flow
+-- (e.g. Authentik callback, Auth0 webhook) end up in public.users. Email
+-- sign-ups and any OAuth provider brokered directly by Supabase Auth would
+-- be silently missing from the vendor-independent table.
+--
+-- This trigger fires on every auth.users INSERT and on targeted UPDATEs so
+-- that 100% of Supabase Auth users are always reflected in public.users —
+-- regardless of how they signed up.
+--
+-- IDENTITY MAPPING
+-- ────────────────
+--   sub = auth.users.id::text   (the Supabase UUID, stable forever)
+--   iss = 'supabase'            (distinguishes from external OIDC issuers)
+--
+-- EVENTS COVERED
+-- ──────────────
+--   INSERT                  → new sign-up (email or OAuth via Supabase)
+--   UPDATE email_confirmed_at → user clicked the confirmation link
+--                               → email_verified flips from false → true
+--   UPDATE email            → user changed their email address
+--   UPDATE raw_user_meta_data → profile updated (name, picture, …)
+--   UPDATE raw_app_meta_data  → provider/role metadata updated
+--
+-- BACKFILL
+-- ────────
+-- The INSERT … SELECT at the bottom runs once during migration to sync all
+-- existing auth.users rows that pre-date this migration.
+-- =============================================================================
+
+-- ─── Trigger function ────────────────────────────────────────────────────────
+
+create or replace function public.sync_auth_user_to_app_users()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Skip Supabase anonymous auth users (is_anonymous = true).
+  -- They have no real identity to preserve in the vendor-independent table.
+  if new.is_anonymous then
+    return new;
+  end if;
+
+  -- Upsert into public.users using the Supabase user's UUID as sub and the
+  -- literal string 'supabase' as iss. This key space is separate from any
+  -- external OIDC issuer URLs, so both can coexist in the same table.
+  insert into public.users (
+    sub,
+    iss,
+    email,
+    email_verified,
+    name,
+    picture,
+    provider,
+    raw_claims
+  )
+  values (
+    new.id::text,
+    'supabase',
+    new.email,
+    -- email_confirmed_at being non-null means the user clicked the magic link
+    -- or entered the OTP — their email is verified.
+    new.email_confirmed_at is not null,
+    coalesce(
+      new.raw_user_meta_data->>'name',
+      new.raw_user_meta_data->>'full_name',
+      -- Fallback: derive a display name from the email local-part
+      split_part(coalesce(new.email, ''), '@', 1)
+    ),
+    new.raw_user_meta_data->>'avatar_url',
+    -- raw_app_meta_data->>'provider' is set by Supabase Auth:
+    --   'email'   for email/password sign-ups
+    --   'google'  for Google OAuth
+    --   'github'  for GitHub OAuth  … etc.
+    coalesce(new.raw_app_meta_data->>'provider', 'email'),
+    coalesce(new.raw_user_meta_data, '{}'::jsonb)
+  )
+  on conflict (sub, iss) do update
+    set email          = excluded.email,
+        email_verified = excluded.email_verified,
+        name           = excluded.name,
+        picture        = excluded.picture,
+        provider       = excluded.provider,
+        raw_claims     = excluded.raw_claims,
+        updated_at     = timezone('utc', now());
+
+  return new;
+end;
+$$;
+
+-- ─── Trigger registration ─────────────────────────────────────────────────────
+-- Scoped to the specific columns that carry meaningful identity changes to avoid
+-- firing on every row-level write (e.g. last_sign_in_at updates).
+
+drop trigger if exists trg_auth_users_sync_to_app_users on auth.users;
+
+create trigger trg_auth_users_sync_to_app_users
+after insert
+  or update of email_confirmed_at, email, raw_user_meta_data, raw_app_meta_data
+on auth.users
+for each row
+execute function public.sync_auth_user_to_app_users();
+
+-- ─── Backfill ─────────────────────────────────────────────────────────────────
+-- Sync all Supabase Auth users that existed before this migration was applied.
+-- Safe to re-run: the ON CONFLICT clause makes it idempotent.
+
+insert into public.users (
+  sub, iss, email, email_verified, name, picture, provider, raw_claims
+)
+select
+  u.id::text,
+  'supabase',
+  u.email,
+  u.email_confirmed_at is not null,
+  coalesce(
+    u.raw_user_meta_data->>'name',
+    u.raw_user_meta_data->>'full_name',
+    split_part(coalesce(u.email, ''), '@', 1)
+  ),
+  u.raw_user_meta_data->>'avatar_url',
+  coalesce(u.raw_app_meta_data->>'provider', 'email'),
+  coalesce(u.raw_user_meta_data, '{}'::jsonb)
+from auth.users u
+where not u.is_anonymous
+on conflict (sub, iss) do update
+  set email          = excluded.email,
+      email_verified = excluded.email_verified,
+      name           = excluded.name,
+      picture        = excluded.picture,
+      provider       = excluded.provider,
+      raw_claims     = excluded.raw_claims,
+      updated_at     = timezone('utc', now());


### PR DESCRIPTION
Closes #11

## What this adds

A reference Supabase migration skeleton in `packages/auth/supabase/` for projects using `@edcalderon/auth` that want to keep user identity data **outside** of Supabase's `auth.users` — so they can migrate auth providers without losing data.

```
packages/auth/
└── supabase/
    ├── README.md
    └── migrations/
        ├── 001_create_app_users.sql
        └── 002_sync_auth_users_to_app_users.sql
```

---

## Migration 001 — `public.users`

Creates a vendor-independent user table with an **OIDC-standard `(sub, iss)` identity key**. Multiple auth providers coexist in the same table without collisions:

| Auth method | `sub` | `iss` |
|---|---|---|
| Supabase Auth (email, OAuth) | `auth.users.id` | `'supabase'` |
| Authentik OIDC | Authentik user UUID | issuer URL |
| Auth0 / Firebase / custom OIDC | JWT `sub` | JWT `iss` |

Also adds `upsert_oidc_user()` — a `SECURITY DEFINER` RPC that clients can call with the **anon key** (no service-role credential on the client).

---

## Migration 002 — `auth.users → public.users` sync trigger

A Postgres trigger that keeps every Supabase Auth user automatically replicated into `public.users`:

- Fires on `INSERT` (new email sign-up or OAuth sign-up via Supabase)
- Fires on `UPDATE` of `email_confirmed_at` → flips `email_verified` to `true` when the user confirms their email
- Fires on `UPDATE` of `email`, `raw_user_meta_data`, `raw_app_meta_data` → keeps name, picture, provider in sync
- Skips anonymous users
- Includes a **backfill** `INSERT … SELECT` that syncs all existing `auth.users` rows on first run (idempotent)

```
email sign-up         Google OAuth        Authentik OIDC redirect
      │                    │                       │
      ▼                    ▼                       ▼
  auth.users           auth.users           upsert_oidc_user()
      │                    │                       │
      └────── trigger ─────┘                       │
                  │                                │
                  ▼                                ▼
              public.users  ◄──────────────────────┘
           (sub, iss) unique key
```

---

## Why this matters for multi-project auth

When multiple projects share `@edcalderon/auth`:
- Each project gets its own `public.users` with its own UUID PK — no FK to `auth.users`
- The `(sub, iss)` key means Supabase Auth users and Authentik/OIDC users live side-by-side
- Migration path away from Supabase Auth: `public.users` already has everything, just point the new provider at it

---

## Usage

```bash
cp packages/auth/supabase/migrations/*.sql your-project/supabase/migrations/
supabase db push
```

Pattern developed and battle-tested in [Alternun](https://alternun.co), a project running `@edcalderon/auth` with Authentik OIDC + Supabase Auth simultaneously.